### PR TITLE
Add kanbanbot into tools category

### DIFF
--- a/traces
+++ b/traces
@@ -231,6 +231,7 @@ const REPOSITORIES_CATEGORIES = [
         'PrestaShop/traces',
         'PrestaShop/travis-status-board',
         'PrestaShop/vagrant',
+        'PrestaShop/kanbanbot',
     ],
     'others' => [
         'PrestaShop/prestashop.github.io',


### PR DESCRIPTION
This PR propose to add kanbanbot into 'tools' category.
With this PR, we add kanbanbot into tools category in the [TopContributors](https://contributors.prestashop-project.org/) app.